### PR TITLE
Update README.md deploy badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Toward Generating Experiment-Specific Notebooks in FABRIC
 
-[![JupyterBook](https://github.com/UCAR-SEA/SEA-ISS-Template/actions/workflows/deploy.yml/badge.svg)](https://github.com/UCAR-SEA/SEA-ISS-Template/actions/workflows/deploy.yml)
+[![JupyterBook](https://github.com/UCAR-SEA/SEA-ISS-2025-Toward-Generating-Experiment-Specific-Notebooks-in-Fabric/actions/workflows/deploy.yml/badge.svg)](https://github.com/UCAR-SEA/SEA-ISS-2025-Toward-Generating-Experiment-Specific-Notebooks-in-Fabric/actions/workflows/deploy.yml)
 [![Made withJupyter](https://img.shields.io/badge/Made%20with-Jupyter-green?style=flat-square&logo=Jupyter&color=green)](https://jupyter.org/try)
 ![Static Badge](https://img.shields.io/badge/DOI-10.XXXXX%2Fnnnnn-blue)
 


### PR DESCRIPTION
Updates the README.md deploy badge to point to the correct repository and trigger an update to so we can see the preview again now that the repository has been transferred.